### PR TITLE
Configure xml tv socket path via environment variable

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -22,7 +22,8 @@ ENV MODE="run" \
     LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
     CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \
-    CLEANUP="/tmp/* /var/tmp/* /var/log/* /var/lib/apt/lists/* /var/lib/{apt,dpkg,cache,log}/ /var/cache/apt/archives /usr/share/doc/ /usr/share/man/ /usr/share/locale/ /root/.cpan /root/.cpanm"
+    CLEANUP="/tmp/* /var/tmp/* /var/log/* /var/lib/apt/lists/* /var/lib/{apt,dpkg,cache,log}/ /var/cache/apt/archives /usr/share/doc/ /usr/share/man/ /usr/share/locale/ /root/.cpan /root/.cpanm"\
+    XMLTV_SOCKET_PATH="/xmltv.sock"
 
 COPY root/entrypoint /usr/local/sbin/entrypoint
 COPY root/easyepg.process /usr/local/bin/easyepg.process

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -22,7 +22,8 @@ ENV MODE="run" \
     LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
     CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \
-    CLEANUP="/tmp/* /var/tmp/* /var/log/* /var/lib/apt/lists/* /var/lib/{apt,dpkg,cache,log}/ /var/cache/apt/archives /usr/share/doc/ /usr/share/man/ /usr/share/locale/ /root/.cpan /root/.cpanm"
+    CLEANUP="/tmp/* /var/tmp/* /var/log/* /var/lib/apt/lists/* /var/lib/{apt,dpkg,cache,log}/ /var/cache/apt/archives /usr/share/doc/ /usr/share/man/ /usr/share/locale/ /root/.cpan /root/.cpanm"\
+    XMLTV_SOCKET_PATH="/xmltv.sock"
 
 COPY root/qemu-arm-static /usr/bin/
 COPY root/entrypoint /usr/local/sbin/entrypoint

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -22,7 +22,8 @@ ENV MODE="run" \
     LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
     CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \
-    CLEANUP="/tmp/* /var/tmp/* /var/log/* /var/lib/apt/lists/* /var/lib/{apt,dpkg,cache,log}/ /var/cache/apt/archives /usr/share/doc/ /usr/share/man/ /usr/share/locale/ /root/.cpan /root/.cpanm"
+    CLEANUP="/tmp/* /var/tmp/* /var/log/* /var/lib/apt/lists/* /var/lib/{apt,dpkg,cache,log}/ /var/cache/apt/archives /usr/share/doc/ /usr/share/man/ /usr/share/locale/ /root/.cpan /root/.cpanm"\
+    XMLTV_SOCKET_PATH="/xmltv.sock"
 
 COPY root/qemu-aarch64-static /usr/bin/
 COPY root/entrypoint /usr/local/sbin/entrypoint

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -22,7 +22,8 @@ ENV MODE="run" \
     LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
     CURL_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt" \
-    CLEANUP="/tmp/* /var/tmp/* /var/log/* /var/lib/apt/lists/* /var/lib/{apt,dpkg,cache,log}/ /var/cache/apt/archives /usr/share/doc/ /usr/share/man/ /usr/share/locale/ /root/.cpan /root/.cpanm"
+    CLEANUP="/tmp/* /var/tmp/* /var/log/* /var/lib/apt/lists/* /var/lib/{apt,dpkg,cache,log}/ /var/cache/apt/archives /usr/share/doc/ /usr/share/man/ /usr/share/locale/ /root/.cpan /root/.cpanm"\
+    XMLTV_SOCKET_PATH="/xmltv.sock"
 
 __CROSS_COPY root/qemu-__QEMU_ARCH__-static /usr/bin/
 COPY root/entrypoint /usr/local/sbin/entrypoint

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ docker run \
   -e UPDATE="yes" \
   -e REPO="sunsettrack4" \
   -e BRANCH="master" \
+  -e XMLTV_SOCKET_PATH="/xmltv.sock" \
   -v {EASYEPG_STORAGE}:/easyepg \
   -v {XML_STORAGE}:/easyepg/xml \
   -v {XMLTV_SOCKET}:/xmltv.sock \
@@ -99,6 +100,7 @@ The available parameters in detail:
 | `UPDATE` | yes | yes, no | yes | Flag whether to update easyepg on container start |
 | `REPO` | yes | sunsettrack4, DeBaschdi | sunsettrack4 | The repo to update/install easyepg from |
 | `BRANCH` | yes | [string] | master | The branch to update/install easyepg from |
+| `XMLTV_SOCKET_PATH` | yes | [string] | /xmltv.sock | Path to the xmltv socket to write to |
 
 Frequently used volumes:
  
@@ -126,4 +128,3 @@ If you decide to remove `XML_STORAGE` the finished XML files can be found in the
  │ │ │ │ │
  * * * * *  /command/to/execute
 ```
-

--- a/root/easyepg.process
+++ b/root/easyepg.process
@@ -7,7 +7,7 @@ writeSocket()
   FILES=$(find /easyepg/xml -type f -name "*.xml" -printf "%T@ %p\n" | sort -n | cut -d " " -f 2)
 
   while read -r FILE; do
-    cat ${FILE} | socat - UNIX-CONNECT:/xmltv.sock
+    cat ${FILE} | socat - UNIX-CONNECT:$XMLTV_SOCKET_PATH
 
     echo "> ${FILE}"
   done <<< "${FILES}"
@@ -24,7 +24,7 @@ rm -rf /easyepg/xml/*
 echo "Running easyepg"
 cd /easyepg && /bin/bash /easyepg/epg.sh
 
-if [[ -S /xmltv.sock ]]; then
+if [[ -S "$XMLTV_SOCKET_PATH" ]]; then
   echo "Writing to xmltv.sock..."
 
   writeSocket


### PR DESCRIPTION
I'm running both tvheadend and easy-epg in a docker container. To share the socket between both containers, I need to change the xml tv socket path inside of easy-epg, because I can't mount the socket created by tvheadend to `/xmltv.sock` (where easy-epg expect the socket to be).

This is my full setup I try to run:
```yml
version: "2.1"
services:
  tvheadend:
    image: ghcr.io/linuxserver/tvheadend
    environment:
      - PUID=1099
      - PGID=1099
      - TZ=Europe/Berlin
    volumes:
      - config:/config
      - tvheadend-xmltv-sock:/config/epggrab
    restart: unless-stopped
      
  easyepg:
    image: qoopido/easyepg.minimal
    restart: unless-stopped
    environment:
      - PUID=1099
      - PGID=1099
      - TIMEZONE=Europe/Berlin
      - MODE=run
      - UPDATE=yes
      - XMLTV_SOCKET_PATH=/tvheadend/xmltv.sock
    depends_on:
      - tvheadend
    volumes:
      - easy-epg:/easyepg
      - tvheadend-xmltv-sock:/tvheadend
        
volumes:
  easy-epg:
  config:
  tvheadend-xmltv-sock:
```